### PR TITLE
close auth popup after successful authentication

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -117,11 +117,12 @@ export class AssembleSubmitButtonExtension
     });
     panel.toolbar.addItem('assembleSubmitButton', button);
 
+    let popup: Window;
     let githubAuthButton = new ToolbarButton({
       iconClass: 'fa fa-github assemble-githubAuthButtonIcon',
       onClick: async () => {
         if (!(await isAuthenticated())) {
-          window.open(
+          popup = window.open(
             getEndpointUrl('auth/authorize'),
             '_blank',
             'width=350,height=600'
@@ -155,6 +156,9 @@ export class AssembleSubmitButtonExtension
       if (authenticated) {
         // githubAuthButton.update = 'Already authenticated with GitHub';
         clearInterval(authIntervalId);
+        if (!popup.closed) {
+          popup.close();
+        }
       }
     }
 


### PR DESCRIPTION
this works, but it might be a better idea to put the auth callback and setInterval method inside the onClick event. the callback only has to be run once outside of it, in case the user reloads the page but is still authenticated.
Closes #23