### PR TITLE
update readme instructions for dev setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ jupyter lab build
 
 ### Development Install
 
+Running `make install-develop` will install necessary dependencies and set up the development environment. Alternatively, these steps can be be taken manually with the instructions below
+
 The `jlpm` command is JupyterLab's pinned version of
 [yarn](https://yarnpkg.com/) that is installed with JupyterLab. You may use
 `yarn` or `npm` in lieu of `jlpm` below.
@@ -145,8 +147,8 @@ The `jlpm` command is JupyterLab's pinned version of
 ```bash
 # Clone the repo to your local environment
 # Move to ballet-assemble directory
-# Install server extension
-pip install -e .
+# Install server extension with dev dependencies
+pip install -e .[dev]
 # Register server extension
 jupyter serverextension enable --py ballet_assemble
 # Install dependencies


### PR DESCRIPTION
The dev environment setup instructions are missing the optional dev requirements in `pip install`, which causes the build commands that follow to fail due to missing dependencies.
I've also added a reference to the `make install-develop` command, as it already handles all necessary steps for the dev environment setup.